### PR TITLE
Add Flying Bows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "IllegalStack-OG"]
 	path = IllegalStack-OG
 	url = https://github.com/NotAlexNoyle/IllegalStack-OG
+[submodule "FlyingBow-OG"]
+	path = FlyingBow-OG
+	url = https://github.com/Barny1094875/FlyingBow-OG.git


### PR DESCRIPTION
This is the plugin that adds flying bows as an alternative to Elytras for 1.8 players.